### PR TITLE
Fix the consent loop in UploadsListFragment.

### DIFF
--- a/src/com/google/ytdl/Auth.java
+++ b/src/com/google/ytdl/Auth.java
@@ -14,7 +14,12 @@
 
 package com.google.ytdl;
 
+import com.google.android.gms.common.Scopes;
+import com.google.api.services.youtube.YouTubeScopes;
+
 public class Auth {
     // Register an API key here: https://code.google.com/apis/console
     public static final String KEY = "Replace me with your API key";
+
+    public static final String[] SCOPES = { Scopes.PLUS_PROFILE, YouTubeScopes.YOUTUBE };
 }

--- a/src/com/google/ytdl/MainActivity.java
+++ b/src/com/google/ytdl/MainActivity.java
@@ -130,7 +130,7 @@ public class MainActivity extends Activity implements
 
 			credential = GoogleAccountCredential.usingOAuth2(
 					getApplicationContext(),
-					Arrays.asList(Scopes.PLUS_PROFILE, YouTubeScopes.YOUTUBE));
+					Arrays.asList(Auth.SCOPES));
 			// set exponential backoff policy
 			credential.setBackOff(new ExponentialBackOff());
 

--- a/src/com/google/ytdl/UploadService.java
+++ b/src/com/google/ytdl/UploadService.java
@@ -26,12 +26,11 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.services.youtube.YouTube;
-import com.google.api.services.youtube.YouTubeScopes;
+import com.google.common.collect.Lists;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 
 /**
  * @author Ibrahim Ulukaya <ulukaya@google.com>
@@ -84,7 +83,7 @@ public class UploadService extends IntentService {
         String chosenAccountName = intent.getStringExtra(MainActivity.ACCOUNT_KEY);
 
         credential =
-                GoogleAccountCredential.usingOAuth2(getApplicationContext(), Collections.singleton(YouTubeScopes.YOUTUBE));
+                GoogleAccountCredential.usingOAuth2(getApplicationContext(), Lists.newArrayList(Auth.SCOPES));
         credential.setSelectedAccountName(chosenAccountName);
         credential.setBackOff(new ExponentialBackOff());
 

--- a/src/com/google/ytdl/UploadsListFragment.java
+++ b/src/com/google/ytdl/UploadsListFragment.java
@@ -15,7 +15,8 @@
 package com.google.ytdl;
 
 import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GooglePlayServicesClient;
+import com.google.android.gms.common.GooglePlayServicesClient.ConnectionCallbacks;
+import com.google.android.gms.common.GooglePlayServicesClient.OnConnectionFailedListener;
 import com.google.android.gms.plus.PlusClient;
 import com.google.android.gms.plus.PlusOneButton;
 import com.google.api.services.plus.model.Person;
@@ -25,7 +26,6 @@ import com.google.ytdl.util.VideoData;
 
 import android.app.Activity;
 import android.app.Fragment;
-import android.app.ListFragment;
 import android.content.IntentSender;
 import android.os.Bundle;
 import android.util.Log;
@@ -45,9 +45,8 @@ import java.util.List;
  *         <p/>
  *         Left side fragment showing user's uploaded YouTube videos.
  */
-public class UploadsListFragment extends Fragment implements
-        GooglePlayServicesClient.ConnectionCallbacks,
-        GooglePlayServicesClient.OnConnectionFailedListener {
+public class UploadsListFragment extends Fragment implements ConnectionCallbacks,
+        OnConnectionFailedListener {
 
     private Callbacks mCallbacks;
     private ImageWorker mImageFetcher;
@@ -62,7 +61,9 @@ public class UploadsListFragment extends Fragment implements
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mPlusClient = new PlusClient.Builder(getActivity(), this, this).build();
+        mPlusClient = new PlusClient.Builder(getActivity(), this, this)
+                .setScopes(Auth.SCOPES)
+                .build();
     }
 
     @Override
@@ -102,23 +103,15 @@ public class UploadsListFragment extends Fragment implements
     }
 
     @Override
-    public void onStart() {
-        super.onStart();
+    public void onResume() {
+        super.onResume();
         mPlusClient.connect();
     }
 
     @Override
-    public void onStop() {
-        super.onStop();
+    public void onPause() {
+        super.onPause();
         mPlusClient.disconnect();
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        if (mPlusClient.isConnected() && mGridView.getAdapter() != null) {
-            ((UploadedVideoAdapter) mGridView.getAdapter()).notifyDataSetChanged();
-        }
     }
 
     @Override


### PR DESCRIPTION
- Inside UploadsListFragment, the consent dialog is getting launched
  automatically, without user intervention during onConnectionFailed.
  After the consent dialog is launched, onStart gets triggered again
  causing a subsequent connect/onConnectionFailed cycle.
- Use the same scopes throughout the application.
